### PR TITLE
Add config file

### DIFF
--- a/hitit.py
+++ b/hitit.py
@@ -1,13 +1,15 @@
+from skyscraper import config
 from skyscraper.scraper import wizzair
 from skyscraper.models import base as database
-
 from datetime import datetime
+
+CONF = config.CONF
+
 
 if __name__ == '__main__':
 
-    departure_airport = 'IAS'
-    destination_airports = ['LCA', 'TLV', 'BLQ', 'CTA',
-                            'VCE', 'BGY', 'CIA', 'TSF', 'LTN']
+    departure_airport = CONF.wizzair.departure_airport
+    destination_airports = CONF.wizzair.destination_airports.split(',')
 
     database.create_tables(database.database)
     scraper = wizzair.WizzScrapper()

--- a/skyscraper/config/__init__.py
+++ b/skyscraper/config/__init__.py
@@ -1,0 +1,58 @@
+import os
+import configparser
+
+_DEFAULT_CONFIG_FILES = [
+    config_file for config_file in (os.path.join("skyscraper", "config", "skyscraper.conf"),
+                                    os.path.join("skyscraper", "skyscraper.conf"),
+                                    os.path.join("skyscraper", "tmp", "skyscraper.conf"))
+        if os.path.isfile(os.path.join(os.path.curdir, config_file))
+    ]
+
+
+class ConfigParser(object):
+
+    def __init__(self, config_file):
+        self._config = configparser.ConfigParser()
+        self._config.read(config_file)
+
+        for name, section in self._config.iteritems():
+            if not hasattr(self, name):
+                self._add_section(name)
+            self._add_values_to_section(name, section)
+
+    def _add_section(self, name):
+        setattr(self, str(name), Section(str(name)))
+
+    def _add_values_to_section(self, name, section):
+        getattr(self, name).add_values(section.items())
+
+    @property
+    def sections(self):
+        param = self.__dict__
+        param.pop('_config')
+        return param.keys()
+
+
+class Section(object):
+
+    def __init__(self, name):
+        self._name = name
+
+    def add_values(self, values):
+        for name, value in values:
+            try:
+                if float(value) != int(value):
+                    setattr(self, name, float(value))
+                else:
+                    setattr(self, name, int(value))
+            except ValueError:
+                setattr(self, name, str(value))
+
+    def __repr__(self):
+        param = self.__dict__
+        param.pop('_name')
+        return str(param.items())
+
+
+if _DEFAULT_CONFIG_FILES:
+    CONF = ConfigParser(_DEFAULT_CONFIG_FILES[0])

--- a/skyscraper/config/skyscraper.conf
+++ b/skyscraper/config/skyscraper.conf
@@ -1,0 +1,4 @@
+[wizzair]
+url = https://be.wizzair.com/5.0.0/Api/asset/farechart
+departure_airport = IAS
+destination_airports = LCA,TLV,BLQ,CTA,VCE,BGY,CIA,TSF,LTN

--- a/skyscraper/models/base.py
+++ b/skyscraper/models/base.py
@@ -1,6 +1,8 @@
+from skyscraper import config
 import peewee
 
-database = peewee.SqliteDatabase(database="db0")
+CONF = config.CONF
+database = peewee.SqliteDatabase(database=CONF.database.name)
 
 
 class BaseModel(peewee.Model):

--- a/skyscraper/scraper/wizzair.py
+++ b/skyscraper/scraper/wizzair.py
@@ -1,10 +1,13 @@
 import re
 from skyscraper.scraper import base
+from skyscraper import config
+
+CONF = config.CONF
 
 
 class WizzScrapper(base.BaseScrapper):
 
-    URL = 'https://be.wizzair.com/5.0.0/Api/asset/farechart'
+    URL = CONF.wizzair.url
     operator = 'wizzair'
 
     def __init__(self):


### PR DESCRIPTION
The following commit adds suport for config file. All specific details,
such as database name, or airline operator API URL will be added in this
file. The structure is the following: each group of data has a name and
multiple values with values. For example:
[DATABASE]
name = my_database

Values which do not belong to any group are automatically asigned to the
'DEFAULT' group.